### PR TITLE
VLC:fix play store url, remove obsolete or rendundant apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,31 +606,6 @@
               </div>
             </div>
 
-            <!-- Sipdroid -->
-            <div class="media emph-Block">
-              <div class="media-Object">
-                <a href="#!" class="pic-Rounded">
-                  <img src="img/foss/sipdroid.png" alt="Sipdroid" class="floss" />
-                </a>
-              </div>
-              <div class="media-Text">
-                <h2 class="eps">Sipdroid</h2>
-                <p>
-                  Easy to use SIP client
-                </p>
-                <ul>
-                  <li>Price: Free</li>
-                  <li>Min. Android version: 1.5</li>
-                  <li><a href="http://code.google.com/p/sipdroid/" target="_blank">Source code</a></li>
-                </ul>
-                <hr>
-                <a href="https://play.google.com/store/apps/details?id=org.sipdroid.sipua" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.sipdroid.sipua" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid Repository" class="download" /></a>
-                <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="sipdroid" />
-
-              </div>
-            </div>
-
             <!-- CSipSimple -->
             <div class="media emph-Block">
               <div class="media-Object">
@@ -830,7 +805,7 @@
                   <li><a href="http://wiki.videolan.org/Developers_Corner">Source code</a></li>
                 </ul>
                 <hr>
-                <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc.betav7neon" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
+                <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
                 <a href="https://f-droid.org/repository/browse/?fdid=org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vlcplayer" />
               </div>
@@ -915,7 +890,7 @@
                   <li><a href="http://wiki.videolan.org/Developers_Corner">Source code</a></li>
                 </ul>
                 <hr>
-                <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc.betav7neon" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
+                <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
                 <a href="https://f-droid.org/repository/browse/?fdid=org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vlc" />
               </div>
@@ -1288,32 +1263,6 @@
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="fileexplorer" />
               </div>
             </div>
-
-            <!-- Open Manager -->
-            <div class="media emph-Block">
-              <div class="media-Object">
-                <a href="#!" class="pic-Rounded">
-                  <img src="img/foss/openmanager.png" alt="open manager" class="floss" />
-                </a>
-              </div>
-              <div class="media-Text">
-                <h2 class="eps">Open Manager</h2>
-                <p>
-                  Simple File Manager. Also a version for tablets
-                </p>
-                <ul>
-                  <li>Price: Free</li>
-                  <li>Min. Android version: 1.6 (3.0 for tablets)</li>
-                  <li><a href="https://github.com/nexes">Source code</a></li>
-                </ul>
-                <hr>
-                <a href="https://play.google.com/store/apps/details?id=com.nexes.manager" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(Basic)
-                <a href="https://play.google.com/store/apps/details?id=com.nexes.manager.tablet" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(Tablet)
-                <a href="https://f-droid.org/repository/browse/?fdid=com.nexes.manager" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid Repository" class="download" /></a>(Basic)
-                <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="openmanager" />
-              </div>
-            </div>
-
 
             <!-- Ghost Commander  -->
             <div class="media emph-Block">


### PR DESCRIPTION
VLC: came out of beta, now uses new package name
Remove SipDroid: Doesn't support ZRTP encryption, CSipSimple and Linphone are excellent clients
Remove Open Manager: No longer on Play Store, F-Droid version very old