### PR TITLE
update metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
             <div class="media-Text">
               <h2 class="eps">TextSecure</h2>
               <p>
-                TextSecure supports push messages over the internet. They run their own server and the cryptography is based on the proven <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">OTR</a> and done by <a href="https://whispersystems.org/">specialists</a>. Group chat is supported and you can send media files. The iOS version is called <a href="https://itunes.apple.com/app/signal-private-messenger/id874139669/" target="_blank">Signal</a>
+                TextSecure supports push messages over the internet. They run their own server and the cryptography is based on the proven <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">OTR</a> and done by <a href="https://whispersystems.org/">specialists</a>. Group chat is supported and you can send media files. The iOS version is called <a href="https://itunes.apple.com/app/signal-private-messenger/id874139669/" target="_blank">Signal</a>.
               </p>
               <ul>
                 <li>Price: Free</li>
@@ -1424,7 +1424,7 @@
 
           <!-- Navigation:Notes -->
           <td class="notes">
-          You can help improve the quality of OpenStreetMap by registering an account and <a href="http://learnosm.org/en/beginner/" target="_blank">mapping your community</a>.
+          You can help improve the quality of OpenStreetMap by registering an account and <a href="http://learnosm.org/en/beginner/start-osm/" target="_blank">mapping your community</a>.
           </td>
         </tr>
       </table>

--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
 
         <!-- Browser:Notes -->
         <td class="notes">
-          Mozilla Firefox uses Google Search by default. Also it promotes add-ons which can use proprietary services. Have a look at <a href="https://prism-break.org/#browser-addons" target="_blank">these add-ons</a> instead.
+          Mozilla Firefox uses Yahoo Search by default. Also it promotes add-ons which can use proprietary services. Have a look at <a href="https://prism-break.org/#browser-addons" target="_blank">these add-ons</a> instead.
         </td>
       </tr>
     </table>
@@ -431,7 +431,6 @@
               <hr>
               <a href="https://play.google.com/store/apps/details?id=com.xabber.android" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(free)
               <a href="https://play.google.com/store/apps/details?id=com.xabber.androidvip" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(supporter)
-              <a href="https://play.google.com/store/apps/details?id=com.xabber.androiddev" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(dev)
               <a href="https://f-droid.org/repository/browse/?fdid=com.xabber.androiddev" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="xabber" />
 
@@ -499,7 +498,7 @@
             <div class="media-Text">
               <h2 class="eps">TextSecure</h2>
               <p>
-                TextSecure was originally an SMS app but now supports push messages over the internet. They run their own server and the cryptography is based on the proven <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">OTR</a> and done by <a href="https://whispersystems.org/">specialists</a>. Group chat is supported and you can send media files. No iOS Version yet.
+                TextSecure supports push messages over the internet. They run their own server and the cryptography is based on the proven <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">OTR</a> and done by <a href="https://whispersystems.org/">specialists</a>. Group chat is supported and you can send media files. The iOS version is called <a href="https://itunes.apple.com/app/signal-private-messenger/id874139669/" target="_blank">Signal</a>
               </p>
               <ul>
                 <li>Price: Free</li>
@@ -685,7 +684,7 @@
 
           <!-- VoIP:Notes -->
           <td class="notes">
-            RedPhone uses special infrastructure, for all other apps you need a SIP account. Have a look on <a href="https://en.wikipedia.org/wiki/SIP_provider" target="_blank">Wikipedia</a> to find a SIP-provider.
+            RedPhone uses special infrastructure, for all other apps you need a SIP account. Have a look on <a href="https://en.wikipedia.org/wiki/SIP_provider" target="_blank">Wikipedia</a> to find a SIP-provider. <a href="https://ostel.co/" target="_blank">Ostel.co</a> is a free encrypted SIP service run by <a href="https://guardianproject.info/" target="_blank">The Guardian Project</a>.
           </td>
         </tr>
       </table>
@@ -1425,6 +1424,7 @@
 
           <!-- Navigation:Notes -->
           <td class="notes">
+          You can help improve the quality of OpenStreetMap by registering an account and <a href="http://learnosm.org/en/beginner/" target="_blank">mapping your community</a>.
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Firefox: uses Yahoo search as default
VoIP: link to ostel.co
Navigation: link to OpenStreetMap
Textsecure: Remove mention of SMS encryption (feature was dropped), add link to iOS version
Xabber: Remove dev version

Note:untested, may need to be checked before release