### PR TITLE
Use new URL format

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=org.mozilla.firefox" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.mozilla.firefox" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="firefox" />
             </div>
           </div>
@@ -166,7 +166,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=acr.browser.barebones" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdfilter=light&amp;fdid=acr.browser.lightning" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/acr.browser.lightning" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="lightningbrowser" />
             </div>
           </div>
@@ -190,7 +190,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.tint" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=org.tint" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.tint" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="tint" />
             </div>
           </div>
@@ -214,7 +214,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.zirco" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=org.zirco" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.zirco" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="zirco" />
             </div>
           </div>
@@ -271,7 +271,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=com.danvelazco.fbwrapper" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=com.danvelazco.fbwrapper" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/com.danvelazco.fbwrapper" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="tinfoil" />
 
             </div>
@@ -296,7 +296,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.mariotaku.twidere" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.mariotaku.twidere" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="twidere" />
 
             </div>
@@ -345,7 +345,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=eu.e43.impeller" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=eu.e43.impeller" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/eu.e43.impeller" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="impeller" />
 
             </div>
@@ -370,7 +370,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.andstatus.app" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=org.andstatus.app" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.andstatus.app" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="andstatus" />
             </div>
           </div>
@@ -431,7 +431,7 @@
               <hr>
               <a href="https://play.google.com/store/apps/details?id=com.xabber.android" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(free)
               <a href="https://play.google.com/store/apps/details?id=com.xabber.androidvip" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(supporter)
-              <a href="https://f-droid.org/repository/browse/?fdid=com.xabber.androiddev" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/com.xabber.androiddev" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="xabber" />
 
             </div>
@@ -456,7 +456,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=info.guardianproject.otr.app.im" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=info.guardianproject.otr.app.im" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/info.guardianproject.otr.app.im" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="chatsecure" />
 
             </div>
@@ -531,7 +531,7 @@
               </ul>
               <hr>
               <a href="https://play.google.com/store/apps/details?id=org.telegram.messenger" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse?fdid=org.telegram.messenger" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://f-droid.org/app/org.telegram.messenger" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="telegram" />
 
             </div>
@@ -624,7 +624,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.csipsimple" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse?fdid=com.csipsimple" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.csipsimple" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="csipsimple" />
 
               </div>
@@ -649,7 +649,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.linphone" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.linphone" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.linphone" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="linphone" />
 
               </div>
@@ -710,7 +710,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=su.thinkdifferent.vanilla" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=ch.blinkenlights.android.vanilla" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" />(other fork)</a>
+                <a href="https://f-droid.org/app/ch.blinkenlights.android.vanilla" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" />(other fork)</a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vanillamusic" />
 
               </div>
@@ -757,7 +757,7 @@
                   <li><a href="https://android.googlesource.com/platform/packages/apps/Music">Source code</a></li>
                 </ul>
                 <hr>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.android.music" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.android.music" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="musicplayer" />
               </div>
             </div>
@@ -805,7 +805,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vlcplayer" />
               </div>
             </div>
@@ -830,7 +830,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=de.danoeh.antennapod" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=de.danoeh.antennapod" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/de.danoeh.antennapod" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="antennapod" />
               </div>
             </div>
@@ -890,7 +890,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.videolan.vlc" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.videolan.vlc" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vlc" />
               </div>
             </div>
@@ -944,7 +944,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.fsck.k9" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.fsck.k9" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.fsck.k9" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="k9" />
               </div>
             </div>
@@ -999,7 +999,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.tomdroid" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.tomdroid" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.tomdroid" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <a href="https://launchpad.net/tomdroid/beta/0.7.3/+download/tomdroid-0.7.3.apk" target="_blank"><img src="apk.png" alt="APK download" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="tomdroid" />
               </div>
@@ -1048,7 +1048,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=info.guardianproject.notepadbot" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=info.guardianproject.notepadbot" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid Repository" class="download" /></a>
+                <a href="https://f-droid.org/app/info.guardianproject.notepadbot" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid Repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="notecipher" />
               </div>
             </div>
@@ -1104,7 +1104,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=de.luhmer.owncloudnewsreader" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=de.luhmer.owncloudnewsreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/de.luhmer.owncloudnewsreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="owncloudnewsreader" />
               </div>
             </div>
@@ -1129,7 +1129,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=net.fred.feedex" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=net.fred.feedex" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/net.fred.feedex" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="feedex" />
 
               </div>
@@ -1154,7 +1154,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.quantumbadger.redreader" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.quantumbadger.redreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.quantumbadger.redreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="redreader" />
 
               </div>
@@ -1179,7 +1179,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.ttrssreader" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.ttrssreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.ttrssreader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="ttrssreader" />
               </div>
             </div>
@@ -1235,7 +1235,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.openintents.filemanager" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.openintents.filemanager" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.openintents.filemanager" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="oifilemanager" />
               </div>
             </div>
@@ -1282,7 +1282,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.ghostsq.commander" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.ghostsq.commander" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.ghostsq.commander" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="ghostcommander" />
               </div>
             </div>
@@ -1339,7 +1339,7 @@
                 <hr> 
                 <a href="https://play.google.com/store/apps/details?id=net.osmand" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(free)
                 <a href="https://play.google.com/store/apps/details?id=net.osmand.plus" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>(pro)
-                <a href="https://f-droid.org/repository/browse/?fdid=net.osmand.plus" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/net.osmand.plus" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="osmand" />
 
               </div>
@@ -1363,7 +1363,7 @@
                 </ul>
                 <hr> 
                 <a href="https://play.google.com/store/apps/details?id=org.navitproject.navit" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.navitproject.navit" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.navitproject.navit" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="navit" />
 
               </div>
@@ -1420,7 +1420,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.pocketworkstation.pckeyboard" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.pocketworkstation.pckeyboard" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.pocketworkstation.pckeyboard" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="hackerskeyboard" />
               </div>
             </div>
@@ -1443,7 +1443,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.menny.android.anysoftkeyboard" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.menny.android.anysoftkeyboard" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.menny.android.anysoftkeyboard" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="anysoftkeyboard" />
               </div>
             </div>
@@ -1498,7 +1498,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.owncloud.android" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.owncloud.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.owncloud.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="owncloud" />
 
               </div>
@@ -1553,7 +1553,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=at.tomtasche.reader" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=at.tomtasche.reader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/at.tomtasche.reader" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="opendocumentreader" />
               </div>
             </div>
@@ -1577,7 +1577,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.artifex.mupdfdemo" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.artifex.mupdfdemo" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.artifex.mupdfdemo" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="mupdf" />
 
               </div>
@@ -1602,7 +1602,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.vudroid" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.vudroid" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.vudroid" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="vudroid" />
 
               </div>
@@ -1627,7 +1627,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=org.geometerplus.zlibrary.ui.android" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=org.geometerplus.zlibrary.ui.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/org.geometerplus.zlibrary.ui.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="fbreader" />
 
               </div>
@@ -1712,7 +1712,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=app.openconnect" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=app.openconnect" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/app.openconnect" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="openconnect" />
               </div>
             </div>
@@ -1736,7 +1736,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=de.blinkt.openvpn" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=de.blinkt.openvpn" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/de.blinkt.openvpn" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="ics-openvpn" />
               </div>
             </div>
@@ -1817,7 +1817,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=com.google.zxing.client.android" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=com.google.zxing.client.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/com.google.zxing.client.android" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="barcodescanner" />
               </div>
             </div>
@@ -1841,7 +1841,7 @@
                 </ul>
                 <hr>
                 <a href="https://play.google.com/store/apps/details?id=cgeo.geocaching" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-                <a href="https://f-droid.org/repository/browse/?fdid=cgeo.geocaching" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+                <a href="https://f-droid.org/app/cgeo.geocaching" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
                 <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="cgeo" />
               </div>
             </div>


### PR DESCRIPTION
https://f-droid.org/app/"package.name" is cleaner and functions better on mobile devices. 

Did some testing in a mobile browser with F-Droid client installed:
When opening https://f-droid.org/repository/browse/?fdid="package.name" attempted to add a repo to F-Droid.
https://f-droid.org/app/"package.name" went straight to the app details screen.

When opened in a non-mobile browser, both links lead to the same page.