### PR TITLE
Writeily URL, + min version OsmAnd

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,10 +912,10 @@
               <ul>
                 <li>Price: Free</li>
                 <li>Min. Android version: 4.1</li>
-                <li><a href="https://github.com/jffrymrtn/writeily-pro" target="_blank">Source code</a></li>
+                <li><a href="https://github.com/plafue/writeily-pro" target="_blank">Source code</a></li>
               </ul>
               <hr>
-              <a href="https://play.google.com/store/apps/details?id=me.writeily.pro" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
+              <a href="https://play.google.com/store/apps/details?id=me.writeily" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
               <a href="https://f-droid.org/repository/browse/?fdid=me.writeily.pro" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="writeilypro" />
             </div>
@@ -1273,7 +1273,7 @@
                 </p>
                 <ul>
                   <li>Price: Free for 10 regions (unlimited regions: 5.99 &euro;)</li>
-                  <li>Min. Android version: 2.1</li>
+                  <li>Min. Android version: 2.3</li>
                   <li><a href="https://github.com/osmandapp/Osmand/">Source code</a></li>
                 </ul>
                 <hr> 


### PR DESCRIPTION
Writeily Pro has changed ownership

https://github.com/plafue/writeily-pro

OsmAnd 2.0+ requires Android version 2.3+

https://f-droid.org/repository/browse/?fdid=net.osmand.plus