### PR TITLE
Update LibreOffice Viewer package name

### DIFF
--- a/index.html
+++ b/index.html
@@ -1539,8 +1539,8 @@
                 <li><a href="http://cgit.freedesktop.org/libreoffice/core/tree" target="_blank">Source code</a></li>
               </ul>
               <hr>
-              <a href="https://play.google.com/store/apps/details?id=com.collabora.libreoffice" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
-              <a href="https://f-droid.org/repository/browse/?fdid=com.collabora.libreoffice" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
+              <a href="https://play.google.com/store/apps/details?id=org.documentfoundation.libreoffice" target="_blank"><img src="img/misc/playstore.png" alt="Google Playstore" class="download" /></a>
+              <a href="https://f-droid.org/repository/browse/?fdid=org.documentfoundation.libreoffice" target="_blank"><img src="img/misc/fdroid.png" alt="F-Droid repository" class="download" /></a>
               <img src="img/misc/qr.gif" alt="QR code" class="download qr" id="libreofficeviewer" />
             </div>
           </div>


### PR DESCRIPTION
Previous package was a beta, this one is official by The Document Foundation.
http://blog.documentfoundation.org/2015/05/28/the-document-foundation-announces-libreoffice-viewer-for-android/

If it isn't by the time you read this, the F-Droid version will be pushed soon. You may want to hold off on merging until then.